### PR TITLE
More activity work (address enforce, covid message)

### DIFF
--- a/app/Nova/Resources/Activity.php
+++ b/app/Nova/Resources/Activity.php
@@ -207,13 +207,16 @@ class Activity extends Resource
 
             Text::make('Weergavenaam locatie', 'location')
                 ->hideFromIndex()
-                ->rules('nullable', 'string', 'between:2,64')
+                ->rules('required', 'string', 'between:2,64')
                 ->help('Weergavenaam van de locatie.'),
 
             Text::make('Adres locatie', 'location_address')
                 ->hideFromIndex()
-                ->rules('nullable', 'string', 'between:5,255')
-                ->help('Het adres van de locatie. Wordt doorgegeven aan Quant Maps'),
+                ->rules('required_unless:location_type,online', 'max:190')
+                ->help(<<<'LOCATION'
+                    Het adres van de locatie, indien niet geheel online.
+                    Houd, indien onbekend of geheim, "Zwolle, Netherlands" aan.
+                LOCATION),
 
             Select::make('Type locatie', 'location_type')
                 ->hideFromIndex()

--- a/resources/css/tweaks/all.css
+++ b/resources/css/tweaks/all.css
@@ -1,4 +1,5 @@
 /* Loads all tweaks */
 
 @import 'a11y.css';
+@import 'covid-btn.css';
 @import 'stretched-link.css';

--- a/resources/css/tweaks/covid-btn.css
+++ b/resources/css/tweaks/covid-btn.css
@@ -1,0 +1,28 @@
+.covid-btn {
+  @apply inline-block;
+  @apply px-4 py-2;
+  @apply rounded shadow-sm;
+  @apply font-bold text-white no-underline;
+  background-color: #01689b;
+}
+
+.covid-btn:hover, .covid-btn:focus {
+  @apply text-gray-100;
+  background-color: #005c8a;
+}
+
+.covid-btn:active {
+  background-color: #005885;
+}
+
+.covid-btn-wrapper {
+  @apply my-2 block w-full;
+}
+
+.covid-btn-wrapper:last-child {
+  @apply mb-0;
+}
+
+.covid-btn-wrapper:first-child {
+  @apply mt-0;
+}

--- a/resources/views/activities/bits/sidebar.blade.php
+++ b/resources/views/activities/bits/sidebar.blade.php
@@ -132,6 +132,11 @@ $showJoin ??= false;
 $showMeta ??= false;
 $showTagline ??= true;
 
+$showCovidWarning = Str::contains(
+    Str::lower($activity->cancelled_reason ?? $activity->postponed_reason ?? $activity->rescheduled_reason ?? ''),
+    ['covid', 'corona', 'covid19', 'coronavirus']
+);
+
 @endphp
 
 {{-- Activity title --}}
@@ -156,6 +161,7 @@ $showTagline ??= true;
     <p class="m-0 w-full">
         {{ $activity->cancelled_reason ?: 'Deze activiteit is geannuleerd.' }}
     </p>
+    @includeWhen($showCovidWarning, 'covid19.block')
 </div>
 @else
 {{-- Description --}}
@@ -185,6 +191,7 @@ $toDate = $activity->start_date->isoFormat('D MMM Y, HH:mm (z)');
             naar <time class="inline-block font-bold" datetime="{{ $toDateIso }}">{{ $toDate }}</time>.
         @endif
     </p>
+    @includeWhen($showCovidWarning, 'covid19.block')
 </div>
 @elseif ($activity->is_postponed && !$activity->is_cancelled)
 @php
@@ -201,6 +208,7 @@ $onDate = $activity->postponed_at->isoFormat('D MMM Y, HH:mm (z)');
             Een nieuwe datum is <strong class="inline-block">nog niet bekend</strong>.
         @endif
     </p>
+    @includeWhen($showCovidWarning, 'covid19.block')
 </div>
 @endif
 @if ($showTagline)

--- a/resources/views/covid19/block.blade.php
+++ b/resources/views/covid19/block.blade.php
@@ -1,0 +1,3 @@
+<p class="covid-btn-wrapper">
+    @include('covid19.link')
+</p>

--- a/resources/views/covid19/link.blade.php
+++ b/resources/views/covid19/link.blade.php
@@ -1,0 +1,5 @@
+<a href="https://www.rijksoverheid.nl/onderwerpen/coronavirus-covid-19" rel="friend" target="__blank"
+    class="covid-btn">
+    @icon('solid/shield-virus', 'mr-1')
+    Meer informatie
+</a>


### PR DESCRIPTION
- [x] Require a location, and an address if not online-only
- [x] Show a link to Rijksoverheid on changes to activities mentioning covid.