### PR TITLE
[hotfix] Update quotes date

### DIFF
--- a/app/Console/Kernel.php
+++ b/app/Console/Kernel.php
@@ -49,7 +49,7 @@ class Kernel extends ConsoleKernel
         $schedule->command('cloudflare:reload')->dailyAt('04:44');
 
         // Send quotes weekly
-        $schedule->job(SendBotQuotes::class)->weeklyOn('monday', '08:15');
+        $schedule->job(SendBotQuotes::class)->weeklyOn(1, '08:15');
     }
 
     /**


### PR DESCRIPTION
`monday` isn't a valid day of the week, that should be `1`.