### PR TITLE
Bug php version constraints

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -174,10 +174,7 @@
     "config": {
         "preferred-install": "dist",
         "sort-packages": true,
-        "optimize-autoloader": true,
-        "platform": {
-          "php": "7.4.1"
-        }
+        "optimize-autoloader": true
     },
     "minimum-stability": "dev",
     "prefer-stable": true,

--- a/composer.lock
+++ b/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "c7e2d6e42472592ad9a3e4d1ddd8b44b",
+    "content-hash": "44100808d724716122c29c64c17fda1a",
     "packages": [
         {
             "name": "advoor/nova-editor-js",
@@ -6444,6 +6444,12 @@
                 "laravel-flash",
                 "spatie"
             ],
+            "funding": [
+                {
+                    "url": "https://spatie.be/open-source/support-us",
+                    "type": "custom"
+                }
+            ],
             "time": "2020-03-18T09:23:45+00:00"
         },
         {
@@ -6580,6 +6586,12 @@
                 "spatie",
                 "state"
             ],
+            "funding": [
+                {
+                    "url": "https://spatie.be/open-source/support-us",
+                    "type": "custom"
+                }
+            ],
             "time": "2020-03-03T19:49:40+00:00"
         },
         {
@@ -6705,6 +6717,12 @@
                 "laravel-stripe-webhooks",
                 "spatie"
             ],
+            "funding": [
+                {
+                    "url": "https://spatie.be/open-source/support-us",
+                    "type": "custom"
+                }
+            ],
             "time": "2020-03-03T10:09:25+00:00"
         },
         {
@@ -6758,6 +6776,12 @@
             "keywords": [
                 "laravel-view-models",
                 "spatie"
+            ],
+            "funding": [
+                {
+                    "url": "https://spatie.be/open-source/support-us",
+                    "type": "custom"
+                }
             ],
             "time": "2020-03-03T09:10:18+00:00"
         },
@@ -7600,6 +7624,20 @@
             ],
             "description": "Symfony Finder Component",
             "homepage": "https://symfony.com",
+            "funding": [
+                {
+                    "url": "https://symfony.com/sponsor",
+                    "type": "custom"
+                },
+                {
+                    "url": "https://github.com/fabpot",
+                    "type": "github"
+                },
+                {
+                    "url": "https://tidelift.com/funding/github/packagist/symfony/symfony",
+                    "type": "tidelift"
+                }
+            ],
             "time": "2020-02-14T07:42:58+00:00"
         },
         {
@@ -9665,6 +9703,12 @@
                 "Xdebug",
                 "performance"
             ],
+            "funding": [
+                {
+                    "url": "https://packagist.com",
+                    "type": "custom"
+                }
+            ],
             "time": "2020-03-01T12:26:26+00:00"
         },
         {
@@ -9774,6 +9818,12 @@
                 "facade",
                 "flare",
                 "reporting"
+            ],
+            "funding": [
+                {
+                    "url": "https://www.patreon.com/spatie",
+                    "type": "patreon"
+                }
             ],
             "time": "2020-03-02T15:52:04+00:00"
         },
@@ -12255,7 +12305,5 @@
         "php": "^7.4 | ^8.0"
     },
     "platform-dev": [],
-    "platform-overrides": {
-        "php": "7.4.1"
-    }
+    "plugin-api-version": "1.1.0"
 }


### PR DESCRIPTION
This PR fixes the php version constraints.

Because the composer config made the php version fixed, and not dependant on the system's version, you could do a `composer install` with an older php installation. This shouldn't be possible, and this PR fixes that.

It also updated most of the dependencies.