### PR TITLE
Fixed limited-discounted events breaking after limit

### DIFF
--- a/app/Services/Traits/HandlesStripeInvoices.php
+++ b/app/Services/Traits/HandlesStripeInvoices.php
@@ -166,8 +166,11 @@ trait HandlesStripeInvoices
         $computed = $this->getComputedInvoiceLines($enrollment);
         $this->createPendingInvoiceItems($customer, $computed);
 
-        // Add discount, if any
-        $coupon = $this->getCoupon($enrollment->activity);
+        // Add discount, if applicable
+        $coupon = null;
+        if ($enrollment->price === $enrollment->activity->discount_price) {
+            $coupon = $this->getCoupon($enrollment->activity);
+        }
         $this->updateCustomerDiscount($customer, $coupon);
 
         // Create the actual invoice


### PR DESCRIPTION
The invoices would break when the activity started creating non-discounted enrollments for members, which would still get the member discount on stripe.

Luckily, the site broke, otherwise the discount would've been infinitely applied.