### PR TITLE
Display an error message when guests visit member only activities

### DIFF
--- a/app/Http/Controllers/Activities/DisplayController.php
+++ b/app/Http/Controllers/Activities/DisplayController.php
@@ -13,6 +13,7 @@ use App\ViewModels\ActivityViewModel;
 use Artesaos\SEOTools\Facades\JsonLd;
 use Artesaos\SEOTools\Facades\OpenGraph;
 use Artesaos\SEOTools\Facades\SEOMeta;
+use Illuminate\Auth\Access\AuthorizationException;
 use Illuminate\Http\RedirectResponse;
 use Illuminate\Http\Request;
 
@@ -104,7 +105,9 @@ class DisplayController extends Controller
         }
 
         // Ensure the user can see this
-        if (!$request->user()->can('view', $activity)) {
+        try {
+            $this->authorize('view', $activity);
+        } catch (AuthorizationException $e) {
             abort(403, 'activities.errors.no-access');
         }
 

--- a/app/Http/Controllers/Activities/DisplayController.php
+++ b/app/Http/Controllers/Activities/DisplayController.php
@@ -104,7 +104,9 @@ class DisplayController extends Controller
         }
 
         // Ensure the user can see this
-        $this->authorize('view', $activity);
+        if (!$request->user()->can('view', $activity)) {
+            abort(403, 'activities.errors.no-access');
+        }
 
         // Load enrollments
         $activity->load(['enrollments']);

--- a/resources/lang/nl/activities.php
+++ b/resources/lang/nl/activities.php
@@ -10,4 +10,7 @@ return [
         'date-price' => 'Datum- en prijsinstellingen',
         'enrollments' => 'Inschrijving instellingen',
     ],
+    'errors' => [
+        'no-access' => 'Sorry, deze activiteit is alleen voor leden.'
+    ],
 ];

--- a/resources/views/errors/403.blade.php
+++ b/resources/views/errors/403.blade.php
@@ -2,7 +2,7 @@
 
 @php
 $message = __($exception->getMessage());
-if (!empty($message)) {
+if (empty($message)) {
     $message = 'Sorry, jouw account heeft niet de benodigde rechten om deze pagina te zien.';
 }
 @endphp


### PR DESCRIPTION
Guest users will now see an error that explains why they can't see member only activities. This should resolve issue #123 