### PR TITLE
Add available seats in Botman Activities Command

### DIFF
--- a/app/BotMan/Messages/ActivitiesCommand.php
+++ b/app/BotMan/Messages/ActivitiesCommand.php
@@ -55,10 +55,17 @@ class ActivitiesCommand extends AbstractMessage
             if ($activity->is_cancelled) {
                 $line .= " (GEANNULEERD)";
             } elseif ($activity->available_seats > 0 && $activity->price > 0) {
-                $line .= " ($activity->price_label)";
+                $line .= sprintf(
+                    ' (%s, %s / %s %s)',
+                    $activity->price_label,
+                    $activity->available_seats,
+                    $activity->seats,
+                    $activity->available_seats === 1 ? 'plek' : 'plekken'
+                );
             } elseif ($activity->available_seats === 0) {
                 $line .= " (uitverkocht)";
             }
+
 
             // Add line
             $lines[] = $line;


### PR DESCRIPTION
Fixes #124 
As per discussion in the issue, I added the available seats in the botman ActivitiesCommands

> Activiteiten 🎯
> 
> 14-10 | Intro 2020 (€ 35,29, 26 / 40 plekken)
> 
> Voor meer info, check de site of het activiteitenkanaal

