### PR TITLE
Fixed Laravel Nova not loading properly when it's available

### DIFF
--- a/app/Providers/AppServiceProvider.php
+++ b/app/Providers/AppServiceProvider.php
@@ -125,9 +125,27 @@ class AppServiceProvider extends ServiceProvider
             'success' => "notice notice--brand",
         ]);
 
-        // Bind Laravel Nova if it's available
-        if (Config::get('services.features.enable-nova')) {
-            $this->app->register(NovaServiceProvider::class);
+        // Registrer Laravel Nova
+        $this->registerNova();
+    }
+
+    /**
+     * Safely registers Nova if it's enabled and available
+     */
+    private function registerNova(): void
+    {
+        // Check if Nova is enabled to begin with
+        if (!Config::get('services.features.enable-nova')) {
+            return;
         }
+
+        // Check if Nova is available, disable if not
+        if (!class_exists(\Laravel\Nova\NovaServiceProvider::class)) {
+            Config::set('services.features.enable-nova', false);
+            return;
+        }
+
+        // Load Nova service provider
+        $this->app->register(NovaServiceProvider::class);
     }
 }

--- a/config/services.php
+++ b/config/services.php
@@ -45,8 +45,6 @@ return [
      */
     'features' => [
         // Only enable Laravel Nova if installed and not disabled by the user
-        'enable-nova' =>
-            class_exists(\Laravel\Nova\NovaServiceProvider::class) &&
-            env('FEATURE_DISABLE_NOVA', false) === true
+        'enable-nova' => env('FEATURE_DISABLE_NOVA', false) !== true
     ]
 ];

--- a/phpcs.xml
+++ b/phpcs.xml
@@ -10,6 +10,7 @@
   <file>database/</file>
   <file>routes/</file>
   <file>tests/</file>
+  <file>library/composer/</file>
 
   <!-- Ignore some dependency paths -->
   <exclude-pattern type="relative">^/vendor/</exclude-pattern>


### PR DESCRIPTION
The `config:cache` command does not account for `class_exists` and doesn't properly autoload by the looks of it.

Disabling Nova gains some additional speed boosts, but if it's enabled, we're calling `NovaServiceProvider` anyway, so no real speed loss there.