### PR TITLE
Fix shop order handling

### DIFF
--- a/app/Nova/Actions/Shop/UpdateOrder.php
+++ b/app/Nova/Actions/Shop/UpdateOrder.php
@@ -1,0 +1,108 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Nova\Actions\Shop;
+
+use App\Jobs\Shop\UpdateOrderJob;
+use App\Models\Shop\Order;
+use App\Nova\Resources\Shop\Order as NovaOrder;
+use Illuminate\Bus\Queueable;
+use Illuminate\Queue\InteractsWithQueue;
+use Illuminate\Queue\SerializesModels;
+use Illuminate\Support\Collection;
+use Illuminate\Support\Facades\Log;
+use Laravel\Nova\Actions\Action;
+use Laravel\Nova\Fields\ActionFields;
+use RuntimeException;
+
+class UpdateOrder extends Action
+{
+    use InteractsWithQueue;
+    use Queueable;
+    use SerializesModels;
+
+    /**
+     * The displayable name of the action.
+     *
+     * @var string
+     */
+    public $name = 'Bijwerken';
+
+    /**
+     * The text to be used for the action's confirm button.
+     *
+     * @var string
+     */
+    public $confirmButtonText = 'Update order';
+
+    /**
+     * The text to be used for the action's confirmation text.
+     *
+     * @var string
+     */
+    public $confirmText = 'This will force an update from Mollie, in case the order has gotten out-of-sync for some reason.';
+
+    /**
+     * Indicates if this action is available on the resource index view.
+     *
+     * @var bool
+     */
+    public $showOnIndex = false;
+
+    /**
+     * Indicates if this action is available on the resource's table row.
+     *
+     * @var bool
+     */
+    public $showOnTableRow = true;
+
+    /**
+     * Get the displayable name of the action.
+     */
+    public function name(): string
+    {
+        return __($this->name);
+    }
+
+    public function handle(ActionFields $fields, Collection $models)
+    {
+        $updatedItems = 0;
+
+        foreach ($models as $order) {
+            // Get the inner order
+            if ($order instanceof NovaOrder) {
+                $order = $order->model();
+            }
+
+            try {
+                // Trigger an update
+                UpdateOrderJob::dispatchNow($order);
+
+                // Done
+                $updatedItems++;
+            } catch (RuntimeException $exception) {
+                Log::warning('Manual update of {order} failed: {exception}.', [
+                    'order' => $order->number,
+                    'exception' => $exception,
+                ]);
+            } catch (\Error $error) {
+                Log::error('Server error for {order}: {exception}.', [
+                    'order' => $order->number,
+                    'exception' => $error,
+                ]);
+            }
+        }
+
+        $totalItems = $models->count();
+
+        if ($totalItems === $updatedItems) {
+            return Action::message(__('All orders have been updated.'));
+        }
+
+        return Action::danger(__(':updated of :total order(s) have been updated.', [
+            ':updated' => $updatedItems,
+            ':total' => $totalItems,
+        ]));
+    }
+}

--- a/app/Nova/Actions/Shop/UpdateOrder.php
+++ b/app/Nova/Actions/Shop/UpdateOrder.php
@@ -7,6 +7,7 @@ namespace App\Nova\Actions\Shop;
 use App\Jobs\Shop\UpdateOrderJob;
 use App\Models\Shop\Order;
 use App\Nova\Resources\Shop\Order as NovaOrder;
+use Error;
 use Illuminate\Bus\Queueable;
 use Illuminate\Queue\InteractsWithQueue;
 use Illuminate\Queue\SerializesModels;
@@ -86,7 +87,7 @@ class UpdateOrder extends Action
                     'order' => $order->number,
                     'exception' => $exception,
                 ]);
-            } catch (\Error $error) {
+            } catch (Error $error) {
                 Log::error('Server error for {order}: {exception}.', [
                     'order' => $order->number,
                     'exception' => $error,

--- a/app/Nova/Resources/Shop/Order.php
+++ b/app/Nova/Resources/Shop/Order.php
@@ -8,6 +8,7 @@ use App\Contracts\Payments\PayableModel;
 use App\Models\Shop\Order as Model;
 use App\Nova\Actions\Shop\CancelOrder;
 use App\Nova\Actions\Shop\ShipOrder;
+use App\Nova\Actions\Shop\UpdateOrder;
 use App\Nova\Fields\Price;
 use App\Nova\Filters\PayableStatusFilter;
 use App\Nova\Resources\Resource;
@@ -122,6 +123,7 @@ class Order extends Resource
     public function actions(Request $request)
     {
         return [
+            new UpdateOrder(),
             new ShipOrder(),
             new CancelOrder(),
         ];

--- a/app/Services/PaymentService.php
+++ b/app/Services/PaymentService.php
@@ -152,7 +152,10 @@ class PaymentService implements PaymentServiceContract
             return null;
         }
 
-        return object_get($order->_links, 'dashboard');
+        $link = object_get($order->_links, 'dashboard._href')
+            ?? object_get($order->_links, 'dashboard');
+
+        return is_string($link) ? $link : null;
     }
 
     public function getRedirectUrl(PayableModel $model): ?string

--- a/resources/lang/nl.json
+++ b/resources/lang/nl.json
@@ -140,5 +140,12 @@
   "If you’re having trouble clicking the \":actionText\" button, copy and paste the URL below\ninto your web browser:":
     "Als je problemen ervaart met de \":actionText\" knop,\nkopieer en plak dan de volgende URL in je browser:\n",
 
+  "Update": "Bijwerken",
+  "Update order": "Bestelling bijwerken",
+  "This will force an update from Mollie, in case the order has gotten out-of-sync for some reason.":
+    "Dit forceert dat een update wordt opgehaald vanuit Mollie. In het geval dat de bestelling bijvoorbeeld niet correct is bijgewerkt.",
+  "All orders have been updated.": "Alle bestellingen zijn bijgewerkt.",
+  ":updated of :total order(s) have been updated.": ":updated van :total bestellingen zijn bijgewerkt.",
+
   "Leave be me down here, please 🥺": "Laat mij benedenaan het bestand staan, voor git diffs"
 }

--- a/resources/views/mail/shop/board.blade.php
+++ b/resources/views/mail/shop/board.blade.php
@@ -15,7 +15,7 @@ Er is een bestelling binnengekomen voor de merchandise van Gumbo Millennium.
 
 De bestelling is voor {{ $order->user->name }}.
 
-Je kan de details zien [in het Mollie dashboard]({{ dashboardUrl }}), of op de website, onder nummer **{{ $order->number }}**.
+Je kan de details zien [in het Mollie dashboard]({{ $dashboardUrl }}), of op de website, onder nummer **{{ $order->number }}**.
 
 De bestelling:
 


### PR DESCRIPTION
Webhooks were failing on board mails not being sent. 

That's been fixed, and I added a manual "update" action in Nova to the Order resource.

Should fix board mails not being sent, as @markwalet reported.

