### PR TITLE
age restricted shop items

### DIFF
--- a/app/Bots/Commands/ActivitiesCommand.php
+++ b/app/Bots/Commands/ActivitiesCommand.php
@@ -13,6 +13,9 @@ use Illuminate\Support\Facades\Log;
 use Telegram\Bot\Actions;
 use Telegram\Bot\Keyboard\Keyboard;
 
+/**
+ * @codeCoverageIgnore
+ */
 class ActivitiesCommand extends Command
 {
     private const ACTIVITY_URL = 'https://gumbo.nu/acpublicaties';

--- a/app/Bots/Commands/BeerCommand.php
+++ b/app/Bots/Commands/BeerCommand.php
@@ -10,6 +10,9 @@ use Illuminate\Support\Facades\Date;
 use Symfony\Component\Yaml\Exception\ParseException;
 use Symfony\Component\Yaml\Yaml;
 
+/**
+ * @codeCoverageIgnore
+ */
 class BeerCommand extends Command
 {
     private const BEER_CONFIG_TEMPLATE = 'assets/yaml/%s.yaml';

--- a/app/Bots/Commands/Command.php
+++ b/app/Bots/Commands/Command.php
@@ -18,6 +18,9 @@ use Telegram\Bot\FileUpload\InputFile;
 use Telegram\Bot\Objects\Message;
 use Telegram\Bot\Objects\User as TelegramUser;
 
+/**
+ * @codeCoverageIgnore
+ */
 abstract class Command extends TelegramCommand
 {
     /**

--- a/app/Bots/Commands/HelpCommand.php
+++ b/app/Bots/Commands/HelpCommand.php
@@ -6,6 +6,9 @@ namespace App\Bots\Commands;
 
 use Telegram\Bot\Commands\CommandInterface;
 
+/**
+ * @codeCoverageIgnore
+ */
 class HelpCommand extends Command
 {
     private const MSG = <<<'TEXT'

--- a/app/Bots/Commands/LeaderboardCommand.php
+++ b/app/Bots/Commands/LeaderboardCommand.php
@@ -8,6 +8,9 @@ use App\Models\MemberReferral;
 use Illuminate\Support\Facades\DB;
 use Telegram\Bot\Actions;
 
+/**
+ * @codeCoverageIgnore
+ */
 class LeaderboardCommand extends Command
 {
     private const EMOJI = ['🥇', '🥈', '🥉'];

--- a/app/Bots/Commands/LoginCommand.php
+++ b/app/Bots/Commands/LoginCommand.php
@@ -9,6 +9,9 @@ use Telegram\Bot\Actions;
 use Telegram\Bot\Exceptions\TelegramSDKException;
 use Telegram\Bot\Keyboard\Keyboard;
 
+/**
+ * @codeCoverageIgnore
+ */
 class LoginCommand extends Command
 {
     private const LOGOUT_MSG = <<<'TEXT'

--- a/app/Bots/Commands/LogoutCommand.php
+++ b/app/Bots/Commands/LogoutCommand.php
@@ -7,6 +7,9 @@ namespace App\Bots\Commands;
 use Illuminate\Support\Facades\Log;
 use Telegram\Bot\Actions;
 
+/**
+ * @codeCoverageIgnore
+ */
 class LogoutCommand extends Command
 {
     private const LOGOUT_OK = <<<'TEXT'

--- a/app/Bots/Commands/PlazaCamCommand.php
+++ b/app/Bots/Commands/PlazaCamCommand.php
@@ -12,6 +12,9 @@ use Illuminate\Support\Facades\Storage;
 use Telegram\Bot\Actions;
 use Telegram\Bot\FileUpload\InputFile;
 
+/**
+ * @codeCoverageIgnore
+ */
 class PlazaCamCommand extends Command
 {
     private const REPLY_GUEST = <<<'MSG'

--- a/app/Bots/Commands/QuoteCommand.php
+++ b/app/Bots/Commands/QuoteCommand.php
@@ -9,6 +9,9 @@ use Illuminate\Support\Facades\Cache;
 use Telegram\Bot\Actions;
 use Telegram\Bot\Keyboard\Keyboard;
 
+/**
+ * @codeCoverageIgnore
+ */
 class QuoteCommand extends Command
 {
     private const REPLY_INVALID = <<<'MSG'

--- a/app/Bots/Commands/SackCommand.php
+++ b/app/Bots/Commands/SackCommand.php
@@ -6,6 +6,9 @@ namespace App\Bots\Commands;
 
 use Telegram\Bot\Actions;
 
+/**
+ * @codeCoverageIgnore
+ */
 class SackCommand extends Command
 {
     /**

--- a/app/Bots/Commands/StartCommand.php
+++ b/app/Bots/Commands/StartCommand.php
@@ -4,6 +4,9 @@ declare(strict_types=1);
 
 namespace App\Bots\Commands;
 
+/**
+ * @codeCoverageIgnore
+ */
 class StartCommand extends Command
 {
     private const MSG = <<<'TEXT'

--- a/app/Bots/Models/Invoice.php
+++ b/app/Bots/Models/Invoice.php
@@ -16,6 +16,7 @@ use Illuminate\Support\Facades\Config;
  * @method self disableNotification(bool $disableNotification)
  * @method self allowSendingWithoutReply(bool $allowSendingWithoutReply)
  * @method static self make(array|string $title = [], ?string $description = null)
+ * @codeCoverageIgnore
  */
 class Invoice extends TelegramObject
 {

--- a/app/Bots/Models/Message.php
+++ b/app/Bots/Models/Message.php
@@ -11,6 +11,7 @@ namespace App\Bots\Models;
  * @method self disableNotification(bool $disableNotification)
  * @method self allowSendingWithoutReply(bool $allowSendingWithoutReply)
  * @method static self make(array|string $text = [])
+ * @codeCoverageIgnore
  */
 class Message extends TelegramObject
 {

--- a/app/Bots/Models/Poll.php
+++ b/app/Bots/Models/Poll.php
@@ -14,6 +14,7 @@ use InvalidArgumentException;
  * @method self allowsMultipleAnswers(bool $allowsMultipleAnswers)
  * @method self openPeriod(int $openPeriod)
  * @method static self make(array|string $question = [])
+ * @codeCoverageIgnore
  */
 class Poll extends TelegramObject
 {

--- a/app/Bots/Models/TelegramObject.php
+++ b/app/Bots/Models/TelegramObject.php
@@ -13,6 +13,7 @@ use Telegram\Bot\Keyboard\Keyboard;
  * @method self disableNotification(bool $disableNotification)
  * @method self replyToMessageId(string $replyToMessageId)
  * @method self allowSendingWithoutReply(bool $allowSendingWithoutReply)
+ * @codeCoverageIgnore
  */
 abstract class TelegramObject extends Fluent
 {

--- a/app/Bots/Models/Venue.php
+++ b/app/Bots/Models/Venue.php
@@ -10,6 +10,7 @@ namespace App\Bots\Models;
  * @method self longitude(float $longitude)
  * @method self address(string $address)
  * @method static self make(array|string $title = [])
+ * @codeCoverageIgnore
  */
 class Venue extends TelegramObject
 {

--- a/app/Http/Controllers/Shop/CartController.php
+++ b/app/Http/Controllers/Shop/CartController.php
@@ -15,6 +15,7 @@ use Illuminate\Http\Response;
 use Illuminate\Support\Facades\Config;
 use Illuminate\Support\Facades\Response as ResponseFacade;
 use Illuminate\Support\Str;
+use Spatie\Csp\Directive;
 
 class CartController extends Controller
 {
@@ -22,8 +23,9 @@ class CartController extends Controller
     {
         $cartItems = Cart::getContent()->sortBy('metadata.sort-key');
 
-        $this->addImageUrlsToCspPolicy(
+        $this->addToCsp(
             $cartItems->map(fn ($item) => $item->associatedModel->valid_image_url)->toArray(),
+            Directive::IMG,
         );
 
         return ResponseFacade::view('shop.cart', [

--- a/app/Http/Controllers/Shop/CartController.php
+++ b/app/Http/Controllers/Shop/CartController.php
@@ -54,7 +54,7 @@ class CartController extends Controller
 
         // If an item is matched, simply increase the count
         if ($matchedItem) {
-            $maxCount = $request->getMaxQuantity();
+            $maxCount = $variant->applied_order_limit;
             $addedQuantity = min($maxCount - $matchedItem->quantity, $request->quantity);
 
             if ($addedQuantity > 0) {
@@ -87,6 +87,7 @@ class CartController extends Controller
             'metadata' => [
                 // For some reason IDs are a reflection of the order
                 'sort-key' => "{$product->id}_{$variant->id}",
+                'limit' => $variant->applied_order_limit,
             ],
         ]);
 
@@ -125,11 +126,14 @@ class CartController extends Controller
             return ResponseFacade::redirectToRoute('shop.cart');
         }
 
+        // Get the max quantity from the cart
+        $maxQuantity = $entry->associatedModel->applied_order_limit;
+
         // Update quantity but treat it as an absolute
         Cart::update($entry->id, [
             'quantity' => [
                 'relative' => false,
-                'value' => $quantity,
+                'value' => min($quantity, $maxQuantity),
             ],
         ]);
 

--- a/app/Http/Requests/Shop/CartAddRequest.php
+++ b/app/Http/Requests/Shop/CartAddRequest.php
@@ -21,7 +21,7 @@ class CartAddRequest extends CartRequest
             'quantity' => [
                 'required',
                 'integer',
-                "between:1,{$this->getMaxQuantity()}",
+                'min:1',
             ],
         ];
     }

--- a/app/Http/Requests/Shop/CartRequest.php
+++ b/app/Http/Requests/Shop/CartRequest.php
@@ -20,6 +20,6 @@ abstract class CartRequest extends StoreRequest
      */
     public function getMaxQuantity(): int
     {
-        return Config::get('gumbo.shop.max-quantity', 5);
+        return Config::get('gumbo.shop.order-limit', 5);
     }
 }

--- a/app/Http/Requests/Shop/CartRequest.php
+++ b/app/Http/Requests/Shop/CartRequest.php
@@ -4,8 +4,6 @@ declare(strict_types=1);
 
 namespace App\Http\Requests\Shop;
 
-use Illuminate\Support\Facades\Config;
-
 abstract class CartRequest extends StoreRequest
 {
     /**
@@ -14,12 +12,4 @@ abstract class CartRequest extends StoreRequest
      * @return array
      */
     abstract public function rules();
-
-    /**
-     * Max quantity per variant.
-     */
-    public function getMaxQuantity(): int
-    {
-        return Config::get('gumbo.shop.order-limit', 5);
-    }
 }

--- a/app/Http/Requests/Shop/CartUpdateRequest.php
+++ b/app/Http/Requests/Shop/CartUpdateRequest.php
@@ -20,7 +20,7 @@ class CartUpdateRequest extends CartRequest
             ],
             'quantity' => [
                 'required',
-                "between:0,{$this->getMaxQuantity()}",
+                'min:0',
             ],
         ];
     }

--- a/app/Models/Shop/Product.php
+++ b/app/Models/Shop/Product.php
@@ -27,11 +27,13 @@ use Illuminate\Support\HtmlString;
  * @property null|string $image_url
  * @property null|string $etag
  * @property int $vat_rate
+ * @property null|int $order_limit
  * @property bool $visible
  * @property bool $advertise_on_home
  * @property array $meta
  * @property array $features
  * @property-read null|\App\Models\Shop\Category $category
+ * @property-read int $applied_order_limit
  * @property-read null|\App\Models\Shop\ProductVariant $default_variant
  * @property-read null|\Illuminate\Support\HtmlString $description_html
  * @property-read Collection $detail_feature_icons
@@ -60,6 +62,9 @@ class Product extends Model
 
         // Tax rate (not really used)
         'vat_rate' => 'int',
+
+        // Max number of items per order (applied per variant)
+        'order_limit' => 'int',
 
         // Random metadata
         'meta' => 'json',
@@ -136,6 +141,15 @@ class Product extends Model
     {
         return $this->getEnrichedFeatures()
             ->filter(fn ($row) => Arr::has($row, 'notice.text'));
+    }
+
+    public function getAppliedOrderLimitAttribute(): int
+    {
+        if ($this->order_limit > 0) {
+            return $this->order_limit;
+        }
+
+        return Config::get('gumbo.shop.order-limit');
     }
 
     private function getEnrichedFeatures(): Collection

--- a/app/Models/Shop/ProductVariant.php
+++ b/app/Models/Shop/ProductVariant.php
@@ -27,8 +27,10 @@ use Illuminate\Support\HtmlString;
  * @property null|string $image_url
  * @property null|string $sku
  * @property null|int $price
+ * @property null|int $order_limit
  * @property array $options
  * @property array $meta
+ * @property-read int $applied_order_limit
  * @property-read null|\Illuminate\Support\HtmlString $description_html
  * @property-read string $display_name
  * @property-read string $url
@@ -67,6 +69,10 @@ class ProductVariant extends Model
     protected $table = 'shop_product_variants';
 
     protected $casts = [
+        // Max number of items per order
+        'order_limit' => 'int',
+
+        // Options and metadata
         'options' => 'json',
         'meta' => 'json',
     ];
@@ -156,5 +162,14 @@ class ProductVariant extends Model
         }
 
         return new HtmlString(nl2br(e(strip_tags($this->description))));
+    }
+
+    public function getAppliedOrderLimitAttribute(): int
+    {
+        if ($this->order_limit > 0) {
+            return $this->order_limit;
+        }
+
+        return $this->product->applied_order_limit;
     }
 }

--- a/app/Models/Webcam.php
+++ b/app/Models/Webcam.php
@@ -14,6 +14,7 @@ use Illuminate\Database\Eloquent\Relations\HasOne;
  * @property int $id
  * @property string $name
  * @property string $slug
+ * @property string $command
  * @property null|\Illuminate\Support\Carbon $created_at
  * @property null|\Illuminate\Support\Carbon $updated_at
  * @property-read bool $is_expired

--- a/app/Nova/Resources/Shop/Product.php
+++ b/app/Nova/Resources/Shop/Product.php
@@ -94,6 +94,15 @@ class Product extends Resource
                 ->min(0)
                 ->max(100),
 
+            Number::make(__('Order limit'), 'order_limit')
+                ->nullable()
+                ->min(1)
+                ->max(255)
+                ->help(implode(' ', [
+                    __('The max count of this variant that can be added to a single order. Counted per variant.'),
+                    __('Can be overruled on the variant level.'),
+                ])),
+
             BooleanGroup::make(__('Features'), 'features')
                 ->options($featuresMap)
                 ->help(__('Additional properties to add to (variants of) this product.')),

--- a/app/Nova/Resources/Shop/Product.php
+++ b/app/Nova/Resources/Shop/Product.php
@@ -8,8 +8,10 @@ use App\Models\Shop\Product as Model;
 use App\Nova\Resources\Resource;
 use Benjaminhirsch\NovaSlugField\Slug;
 use Illuminate\Http\Request;
+use Illuminate\Support\Facades\Config;
 use Laravel\Nova\Fields\BelongsTo;
 use Laravel\Nova\Fields\Boolean;
+use Laravel\Nova\Fields\BooleanGroup;
 use Laravel\Nova\Fields\HasMany;
 use Laravel\Nova\Fields\ID;
 use Laravel\Nova\Fields\Number;
@@ -57,6 +59,10 @@ class Product extends Resource
      */
     public function fields(Request $request)
     {
+        $featuresMap = collect(Config::get('gumbo.shop.features', []))
+            ->mapWithKeys(fn ($row, $key) => [$key => $row['title']])
+            ->all();
+
         return [
             ID::make(),
 
@@ -87,6 +93,10 @@ class Product extends Resource
                 ->hideFromIndex()
                 ->min(0)
                 ->max(100),
+
+            BooleanGroup::make(__('Features'), 'features')
+                ->options($featuresMap)
+                ->help(__('Additional properties to add to (variants of) this product.')),
 
             Boolean::make(__('Visible'), 'visible'),
 

--- a/app/Nova/Resources/Shop/ProductVariant.php
+++ b/app/Nova/Resources/Shop/ProductVariant.php
@@ -12,6 +12,7 @@ use Illuminate\Http\Request;
 use Laravel\Nova\Fields\BelongsTo;
 use Laravel\Nova\Fields\BelongsToMany;
 use Laravel\Nova\Fields\ID;
+use Laravel\Nova\Fields\Number;
 use Laravel\Nova\Fields\Text;
 use Laravel\Nova\Fields\Textarea;
 
@@ -81,6 +82,12 @@ class ProductVariant extends Resource
             Price::make(__('Price'), 'price')
                 ->sortable()
                 ->min(1.00),
+
+            Number::make(__('Order limit'), 'order_limit')
+                ->nullable()
+                ->min(1)
+                ->max(255)
+                ->help(__('The max count of this variant that can be added to a single order.')),
 
             BelongsTo::make(__('Product'), 'product', Product::class)
                 ->searchable(),

--- a/app/Providers/AppServiceProvider.php
+++ b/app/Providers/AppServiceProvider.php
@@ -32,6 +32,8 @@ class AppServiceProvider extends ServiceProvider
 {
     private const ACTIVITY_FEATURES_FILE = 'assets/yaml/activity-features.yaml';
 
+    private const SHOP_FEATURES_FILE = 'assets/yaml/shop-features.yaml';
+
     /**
      * Singleton bindings.
      *
@@ -161,6 +163,7 @@ class AppServiceProvider extends ServiceProvider
 
         $fileMap = [
             self::ACTIVITY_FEATURES_FILE => 'gumbo.activity-features',
+            self::SHOP_FEATURES_FILE => 'gumbo.shop.features',
         ];
 
         foreach ($fileMap as $file => $configKey) {
@@ -168,6 +171,7 @@ class AppServiceProvider extends ServiceProvider
                 $options = array_merge([
                     'title' => null,
                     'icon' => null,
+                    'mail' => null,
                     'notice' => null,
                 ], $options);
 

--- a/app/Providers/AppServiceProvider.php
+++ b/app/Providers/AppServiceProvider.php
@@ -144,20 +144,36 @@ class AppServiceProvider extends ServiceProvider
         ]);
 
         // Bind feature config
-        if (! $this->app->configurationIsCached()) {
-            foreach (Yaml::parseFile(resource_path(self::ACTIVITY_FEATURES_FILE)) as $feature => $options) {
-                $options = array_merge([
-                    'title' => null,
-                    'icon' => null,
-                    'mail' => null,
-                ], $options);
-
-                Config::set("gumbo.activity-features.{$feature}", $options);
-            }
-        }
+        $this->mapFeatures();
 
         // Registrer Laravel Nova
         $this->registerNova();
+    }
+
+    /**
+     * Maps features from Yaml files to config.
+     */
+    private function mapFeatures(): void
+    {
+        if ($this->app->configurationIsCached()) {
+            return;
+        }
+
+        $fileMap = [
+            self::ACTIVITY_FEATURES_FILE => 'gumbo.activity-features',
+        ];
+
+        foreach ($fileMap as $file => $configKey) {
+            foreach (Yaml::parseFile(resource_path($file)) as $feature => $options) {
+                $options = array_merge([
+                    'title' => null,
+                    'icon' => null,
+                    'notice' => null,
+                ], $options);
+
+                Config::set("{$configKey}.{$feature}", $options);
+            }
+        }
     }
 
     /**

--- a/config/gumbo.php
+++ b/config/gumbo.php
@@ -86,7 +86,7 @@ return [
 
     // Shop settings
     'shop' => [
-        'max-quantity' => (int) env('GUMBO_SHOP_MAX_QUANTITY', 5),
+        'order-limit' => (int) env('GUMBO_SHOP_MAX_QUANTITY', 5),
 
         // Seeded from resources/yaml/shop-features.yaml
         'features' => [],

--- a/config/gumbo.php
+++ b/config/gumbo.php
@@ -87,6 +87,9 @@ return [
     // Shop settings
     'shop' => [
         'max-quantity' => (int) env('GUMBO_SHOP_MAX_QUANTITY', 5),
+
+        // Seeded from resources/yaml/shop-features.yaml
+        'features' => [],
     ],
 
     'mail-recipients' => [

--- a/database/factories/Shop/ProductFactory.php
+++ b/database/factories/Shop/ProductFactory.php
@@ -18,6 +18,10 @@ $factory->define(Product::class, static function (Faker $faker) {
     ];
 });
 
+$factory->state(Product::class, 'order-limit', fn (Faker $faker) => [
+    'order_limit' => $faker->numberBetween(1, 10),
+]);
+
 $factory->afterCreatingState(Product::class, 'with-variants', static function (Product $product, Faker $faker) {
     factory(ProductVariant::class, $faker->numberBetween(1, 5))->create([
         'product_id' => $product->id,

--- a/database/factories/Shop/ProductVariantFactory.php
+++ b/database/factories/Shop/ProductVariantFactory.php
@@ -17,3 +17,7 @@ $factory->define(ProductVariant::class, static function (Faker $faker) {
         'order' => $faker->numerify(1, 10),
     ];
 });
+
+$factory->state(ProductVariant::class, 'order-limit', fn (Faker $faker) => [
+    'order_limit' => $faker->numberBetween(1, 10),
+]);

--- a/database/migrations/2021_09_08_231134_add_feature_flags_to_shop_products_table.php
+++ b/database/migrations/2021_09_08_231134_add_feature_flags_to_shop_products_table.php
@@ -1,0 +1,38 @@
+<?php
+
+declare(strict_types=1);
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+class AddFeatureFlagsToShopProductsTable extends Migration
+{
+    /**
+     * Run the migrations.
+     *
+     * @return void
+     */
+    public function up()
+    {
+        Schema::table('shop_products', function (Blueprint $table) {
+            $field = $table->json('features');
+
+            if (DB::getDriverName() === 'sqlite') {
+                $field->default('[]');
+            }
+        });
+    }
+
+    /**
+     * Reverse the migrations.
+     *
+     * @return void
+     */
+    public function down()
+    {
+        Schema::table('shop_products', function (Blueprint $table) {
+            $table->dropColumn('features');
+        });
+    }
+}

--- a/database/migrations/2021_09_09_000125_add_order_limit_to_shop_products_table.php
+++ b/database/migrations/2021_09_09_000125_add_order_limit_to_shop_products_table.php
@@ -1,0 +1,34 @@
+<?php
+
+declare(strict_types=1);
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+class AddOrderLimitToShopProductsTable extends Migration
+{
+    /**
+     * Run the migrations.
+     *
+     * @return void
+     */
+    public function up()
+    {
+        Schema::table('shop_products', function (Blueprint $table) {
+            $table->unsignedTinyInteger('order_limit')->nullable()->default(null)->after('vat_rate');
+        });
+    }
+
+    /**
+     * Reverse the migrations.
+     *
+     * @return void
+     */
+    public function down()
+    {
+        Schema::table('shop_products', function (Blueprint $table) {
+            $table->dropColumn('order_limit');
+        });
+    }
+}

--- a/database/migrations/2021_09_09_000130_add_order_limit_to_shop_product_variants_table.php
+++ b/database/migrations/2021_09_09_000130_add_order_limit_to_shop_product_variants_table.php
@@ -1,0 +1,34 @@
+<?php
+
+declare(strict_types=1);
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+class AddOrderLimitToShopProductVariantsTable extends Migration
+{
+    /**
+     * Run the migrations.
+     *
+     * @return void
+     */
+    public function up()
+    {
+        Schema::table('shop_product_variants', function (Blueprint $table) {
+            $table->unsignedTinyInteger('order_limit')->nullable()->default(null)->after('price');
+        });
+    }
+
+    /**
+     * Reverse the migrations.
+     *
+     * @return void
+     */
+    public function down()
+    {
+        Schema::table('shop_product_variants', function (Blueprint $table) {
+            $table->dropColumn('order_limit');
+        });
+    }
+}

--- a/resources/assets/yaml/shop-features.yaml
+++ b/resources/assets/yaml/shop-features.yaml
@@ -1,0 +1,18 @@
+#
+# Shop feature icons
+#
+# Owner-selectable mails with icons and optionally mail parts.
+#
+
+alcohol:
+  title: Product bevat alcohol
+  icon: solid/wine-bottle
+  notice:
+    type: warning
+    text: |
+      Dit product bevat alcohol. Ben je nog geen 18, dan mag je dit product niet bestellen.
+      We controleren je leeftijd bij afgifte van je bestelling.
+
+limited-edition:
+  title: Limited edition
+  icon: solid/certificate

--- a/resources/lang/nl.json
+++ b/resources/lang/nl.json
@@ -54,6 +54,10 @@
   "Features": "Eigenschappen",
   "Additional properties to add to (variants of) this product.": "Extra eigenschappen die aan (varianten van) dit product moeten worden toegevoegd.",
 
+  "Order limit": "Bestellinglimiet",
+  "The max count of this variant that can be added to a single order.": "Het maximaal aantal van deze variant dat aan een enkele bestelling kan worden toegevoegd.",
+  "Can be overruled on the variant level.": "Kan worden overschreven op het variant-niveau",
+
   "Failed to render body, sorry.": "De content kan helaas niet goed getoond worden, sorry.",
 
   "Member Referral": "Ledenverwijzing",

--- a/resources/lang/nl.json
+++ b/resources/lang/nl.json
@@ -51,6 +51,8 @@
   "Pending": "Niet betaald",
   "Price": "Prijs",
   "Total price": "Totaalprijs",
+  "Features": "Eigenschappen",
+  "Additional properties to add to (variants of) this product.": "Extra eigenschappen die aan (varianten van) dit product moeten worden toegevoegd.",
 
   "Failed to render body, sorry.": "De content kan helaas niet goed getoond worden, sorry.",
 

--- a/resources/views/components/shop-item.blade.php
+++ b/resources/views/components/shop-item.blade.php
@@ -7,9 +7,20 @@ $typecount = $product->variants->count();
 @endphp
 
 <div class="card mb-4">
-    <div class="card__figure" role="presentation">
+    <div class="card__figure relative" role="presentation">
         <img class="card__figure-image" src="{{ $product->valid_image_url }}"
             title="Foto van {{ $product->valid_image_url }}">
+
+        {{-- Features --}}
+        @if ($product->feature_icons->isNotEmpty())
+        <div class="absolute bottom-4 right-4 flex flex-row-reverse items-center mt-2">
+            @foreach ($product->feature_icons as $icon => $feature)
+            <div class="flex items-center ml-4 p-2 bg-white text-black rounded" title="{{ $feature }}">
+                @icon($icon, 'h-4')
+            </div>
+            @endforeach
+        </div>
+        @endif
     </div>
     <div class="card__body">
         <h2 class="card__body-title">

--- a/resources/views/shop/index.blade.php
+++ b/resources/views/shop/index.blade.php
@@ -3,7 +3,7 @@
 {{-- Header --}}
 @section('shop-title', 'Gumbo Millennium Webshop')
 @section('shop-subtitle')
-    het is geen Black Friday, maar deze shit is goed ge<i>prei</i>st.
+    Gumbo Merch tot je groen en geel ziet <span class="text-sm">(maar voornamelijk groen)</span>
 @endsection
 
 @section('shop-adverts')

--- a/resources/views/shop/partials/product-list.blade.php
+++ b/resources/views/shop/partials/product-list.blade.php
@@ -45,13 +45,13 @@
                     {{ $item->quantity }}
                 </data>
 
-                @if ($item->quantity >= 5)
+                @if ($item->quantity >= $item->associatedModel->applied_order_limit)
                     <div role="presentation"
                         class="flex items-center justify-center appearance-none rounded-full h-6 w-6 shadow bg-gray-100 text-gray-500 cursor-not-allowed">
                         @svg('solid/plus', 'h-2')
                     </div>
                 @else
-                    <button name="quantity" value="{{ min($item->quantity + 1, 5) }}"
+                    <button name="quantity" value="{{ min($item->quantity + 1, $item->associatedModel->applied_order_limit) }}"
                         class="flex items-center justify-center appearance-none rounded-full h-6 w-6 shadow bg-brand-primary-1 text-white">
                         @svg('solid/plus', 'h-2')
                     </button>

--- a/resources/views/shop/product.blade.php
+++ b/resources/views/shop/product.blade.php
@@ -25,15 +25,25 @@
 
     <div class="col col-12 md:col-5 lg:col-4 mt-8 md:mt-0">
         {{-- Title --}}
-        <div class="flex flex-row">
-            <div class="mb-8 flex-grow">
-                <h1 class="text-3xl font-title mb-4 font-bold">{{ $product->name }}</h1>
-                <h2 class="text-lg font-title font-grey-2">{{ $variant->name }}</h2>
+        <div class="mb-8">
+            <div class="flex flex-row">
+                <div class="flex-grow">
+                    <h1 class="text-3xl font-title mb-4 font-bold">{{ $product->name }}</h1>
+                    <h2 class="text-lg font-title font-grey-2">{{ $variant->name }}</h2>
+                </div>
             </div>
 
-            {{-- <div class="flex-none mt-1">
-                <data class="text-2xl font-title py-2 px-4 rounded border-gray-primary-1 border mb-4 font-bold"></data>
-            </div> --}}
+            {{-- Features --}}
+            @if ($product->detail_feature_icons)
+            <div class="flex items-center flex-wrap mt-2">
+                @foreach ($product->detail_feature_icons as $icon => $feature)
+                <div class="flex items-center mr-4 mb-4 p-2 bg-gray-100 rounded">
+                    @icon($icon, 'h-4 mr-2')
+                    <span class="text-sm">{{ $feature }}</span>
+                </div>
+                @endforeach
+            </div>
+            @endif
         </div>
 
         {{-- Desc --}}
@@ -48,6 +58,19 @@
                 class="shop-detail__variant {{ $variant->is($productVariant) ? 'shop-detail__variant--active' : '' }} mb-2">
                 {{ $productVariant->name }}
             </a>
+            @endforeach
+        </div>
+        @endif
+
+        {{-- Warning notices, if any --}}
+        @if ($product->feature_warnings)
+        <div class="mb-2 grid grid-cols-1 grid-gap-2">
+            @foreach ($product->feature_warnings as $feature)
+            <div class="notice notice--{{ Arr::get($feature, 'notice.type', 'info') }} notice--large">
+                <h3 class="notice__title">{{ Arr::get($feature, 'title') }}</h3>
+
+                {{ Arr::get($feature, 'notice.text') }}
+            </div>
             @endforeach
         </div>
         @endif

--- a/resources/views/shop/product.blade.php
+++ b/resources/views/shop/product.blade.php
@@ -87,6 +87,10 @@
                 {{ Str::price($variant->price) }}
             </button>
 
+            <p class="text-center text-sm text-gray-primary-2 mb-2 mt-n1">
+                Maximaal {{ $variant->applied_order_limit }} per bestelling
+            </p>
+
             <p class="text-center text-gray-primary-2">
                 <strong>Let op:</strong>
                 Je kan webshop aankopen alleen afhalen

--- a/tests/Feature/Http/Controllers/Shop/CartControllerTest.php
+++ b/tests/Feature/Http/Controllers/Shop/CartControllerTest.php
@@ -218,25 +218,23 @@ class CartControllerTest extends TestCase
             'quantity' => 1,
         ])->assertSessionHasNoErrors();
 
-        $item = Cart::getContent()->first()->id;
-
-        $this->post(route('shop.cart.add'), [
-            'id' => $item,
+        $this->post(route('shop.cart.update'), [
+            'variant' => $variant->id,
             'quantity' => self::SHOP_ORDER_LIMIT * 50,
         ])->assertSessionHasNoErrors()
             ->assertRedirect(route('shop.cart'));
 
-        $this->post(route('shop.cart.add'), [
-            'id' => $item,
+        $this->post(route('shop.cart.update'), [
+            'variant' => $variant->id,
             'quantity' => -100,
         ])->assertSessionHasErrors(['quantity']);
 
-        $this->post(route('shop.cart.add'), [
-            'id' => $item,
+        $this->post(route('shop.cart.update'), [
+            'variant' => $variant->id,
             'quantity' => null,
         ])->assertSessionHasErrors(['quantity']);
 
-        $this->post(route('shop.cart.add'), [
+        $this->post(route('shop.cart.update'), [
             'variant' => $variant->id,
             'quantity' => self::SHOP_ORDER_LIMIT + 1,
         ])->assertSessionHasNoErrors()

--- a/tests/Feature/Models/Shop/ProductTest.php
+++ b/tests/Feature/Models/Shop/ProductTest.php
@@ -2,9 +2,10 @@
 
 declare(strict_types=1);
 
-namespace Tests\Unit\Models\Shop;
+namespace Tests\Feature\Models\Shop;
 
 use App\Models\Shop\Product;
+use Illuminate\Support\Facades\Config;
 use Illuminate\Support\HtmlString;
 use Tests\TestCase;
 
@@ -27,6 +28,25 @@ class ProductTest extends TestCase
 
         $this->assertInstanceOf(HtmlString::class, $model->description_html);
         $this->assertSame($output, (string) $model->description_html);
+    }
+
+    public function test_computing_of_order_limit(): void
+    {
+        Config::set('gumbo.shop.order-limit', 4);
+
+        $model = factory(Product::class)->create();
+
+        $this->assertSame(4, $model->refresh()->applied_order_limit);
+
+        $model->order_limit = 8;
+        $model->save();
+
+        $this->assertSame(8, $model->refresh()->applied_order_limit);
+
+        $model->order_limit = 2;
+        $model->save();
+
+        $this->assertSame(2, $model->refresh()->applied_order_limit);
     }
 
     public function htmlTestProvider(): array


### PR DESCRIPTION
- Refactor AppServiceProvider to allow additional features
- Added features to products
- Updated shop entry text
- Rename gumbo.shop.max-quantity to gumbo.shop.order-limit
- Fixed deprecation
- Reworked cart to support custom order limits
- Tests for custom order limits
- Fixes on tests
- Mark Telegram as not covered by code coverage, the framework is impossible to test
- Missing docblock on webcam
