### PR TITLE
Add responsible owners to the Activities

### DIFF
--- a/app/Models/Activity.php
+++ b/app/Models/Activity.php
@@ -10,6 +10,7 @@ use App\Contracts\FormLayoutContract;
 use App\Helpers\Str;
 use App\Models\States\Enrollment\Cancelled as CancelledState;
 use App\Models\States\Enrollment\Refunded as RefundedState;
+use App\Models\Traits\HasResponsibleUsers;
 use DateTimeInterface;
 use Illuminate\Database\Eloquent\Builder;
 use Illuminate\Database\Eloquent\Factories\HasFactory;
@@ -102,6 +103,7 @@ use Spatie\Permission\Models\Role;
 class Activity extends SluggableModel
 {
     use HasFactory;
+    use HasResponsibleUsers;
 
     public const PAYMENT_TYPE_INTENT = 'intent';
 

--- a/app/Models/Traits/HasResponsibleUsers.php
+++ b/app/Models/Traits/HasResponsibleUsers.php
@@ -1,0 +1,54 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Models\Traits;
+
+use App\Models\User;
+use Illuminate\Database\Eloquent\Relations\BelongsTo;
+use Illuminate\Support\Facades\Auth;
+
+/**
+ * Indicates that this resource has responsible users,
+ * and tracks who made changes to it.
+ *
+ * @property null|int $created_by_id
+ * @property null|int $updated_by_id
+ * @property null|User $created_by User that created this resource.
+ * @property null|User $updated_by User that most recently updated this resource.
+ */
+trait HasResponsibleUsers
+{
+    public static function bootHasResponsibleUsers(): void
+    {
+        static::creating(function ($model) {
+            if ($user = Auth::user()) {
+                $model->created_by()->associate($user);
+            }
+        });
+
+        static::saving(function ($model) {
+            if ($user = Auth::user()) {
+                $model->updated_by()->associate($user);
+            }
+        });
+    }
+
+    /**
+     * User that created this resource.
+     * @return BelongsTo<User>
+     */
+    public function created_by(): BelongsTo
+    {
+        return $this->belongsTo(User::class, 'created_by_id');
+    }
+
+    /**
+     * User that most recently updated this resource.
+     * @return BelongsTo<User>
+     */
+    public function updated_by(): BelongsTo
+    {
+        return $this->belongsTo(User::class, 'updated_by_id');
+    }
+}

--- a/app/Nova/Resources/Activity.php
+++ b/app/Nova/Resources/Activity.php
@@ -341,8 +341,14 @@ class Activity extends Resource
                 ->readonly()
                 ->onlyOnDetail(),
 
+            Fields\BelongsTo::make('Aangemaakt door', 'created_by', User::class)
+                ->onlyOnDetail(),
+
             Fields\DateTime::make('Laatst bewerkt op', 'updated_at')
                 ->readonly()
+                ->onlyOnDetail(),
+
+            Fields\BelongsTo::make('Laatst bewerkt door', 'updated_by', User::class)
                 ->onlyOnDetail(),
 
             Fields\DateTime::make('Geannuleerd op', 'cancelled_at')

--- a/database/migrations/2023_11_07_132759_add_responsible_users_to_activities.php
+++ b/database/migrations/2023_11_07_132759_add_responsible_users_to_activities.php
@@ -1,0 +1,36 @@
+<?php
+
+declare(strict_types=1);
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+class AddResponsibleUsersToActivities extends Migration
+{
+    /**
+     * Run the migrations.
+     *
+     * @return void
+     */
+    public function up()
+    {
+        Schema::table('activities', function (Blueprint $table) {
+            $table->foreignId('created_by_id')->nullable()->constrained('users')->nullOnDelete();
+            $table->foreignId('updated_by_id')->nullable()->constrained('users')->nullOnDelete();
+        });
+    }
+
+    /**
+     * Reverse the migrations.
+     *
+     * @return void
+     */
+    public function down()
+    {
+        Schema::table('activities', function (Blueprint $table) {
+            $table->dropConstrainedForeignId('created_by_id');
+            $table->dropConstrainedForeignId('updated_by_id');
+        });
+    }
+}

--- a/tests/Feature/Models/Traits/HasResponsibleUsersTest.php
+++ b/tests/Feature/Models/Traits/HasResponsibleUsersTest.php
@@ -1,0 +1,107 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Tests\Feature\Models\Traits;
+
+use App\Models\Activity;
+use App\Models\User;
+use Tests\TestCase;
+
+/**
+ * Tests the HasResponsibleUsers trait with the Activity model.
+ */
+class HasResponsibleUsersTest extends TestCase
+{
+    /**
+     * Tests the handles if no user is acting upon stuff.
+     */
+    public function test_system_level_changes(): void
+    {
+        $activity = Activity::factory()->create();
+
+        $this->assertNull($activity->created_by_id);
+        $this->assertNull($activity->created_by);
+
+        $this->assertNull($activity->updated_by_id);
+        $this->assertNull($activity->updated_by);
+
+        $this->travel(5)->minutes();
+
+        $activity->name = 'Test 123';
+
+        $oldChanged = $activity->updated_at;
+        $activity->save();
+
+        $this->assertNotEquals($oldChanged, $activity->updated_at);
+
+        $this->assertNull($activity->created_by_id);
+        $this->assertNull($activity->created_by);
+
+        $this->assertNull($activity->updated_by_id);
+        $this->assertNull($activity->updated_by);
+    }
+
+    /**
+     * Tests the handles if a user is switched between the create and edit.
+     */
+    public function test_with_users(): void
+    {
+        [$user1, $user2] = User::factory(2)->create();
+
+        $this->actingAs($user1);
+
+        $activity = Activity::factory()->create();
+
+        $this->assertEquals($user1->id, $activity->created_by_id);
+        $this->assertTrue($user1->is($activity->created_by));
+
+        $this->assertEquals($user1->id, $activity->updated_by_id);
+        $this->assertTrue($user1->is($activity->updated_by));
+
+        $this->travel(5)->minutes();
+        $this->actingAs($user2);
+
+        $activity->name = 'Test 123';
+
+        $oldChanged = $activity->updated_at;
+        $activity->save();
+
+        $this->assertNotEquals($oldChanged, $activity->updated_at);
+
+        $this->assertEquals($user1->id, $activity->created_by_id);
+        $this->assertTrue($user1->is($activity->created_by));
+
+        $this->assertEquals($user2->id, $activity->updated_by_id);
+        $this->assertTrue($user2->is($activity->updated_by));
+    }
+
+    public function test_create_is_not_touched_on_updates(): void
+    {
+        $user = User::factory()->create();
+
+        $activity = Activity::factory()->create();
+
+        $this->assertNull($activity->created_by_id);
+        $this->assertNull($activity->created_by);
+
+        $this->assertNull($activity->updated_by_id);
+        $this->assertNull($activity->updated_by);
+
+        $this->travel(5)->minutes();
+        $this->actingAs($user);
+
+        $activity->name = 'Test 123';
+
+        $oldChanged = $activity->updated_at;
+        $activity->save();
+
+        $this->assertNotEquals($oldChanged, $activity->updated_at);
+
+        $this->assertNull($activity->created_by_id);
+        $this->assertNull($activity->created_by);
+
+        $this->assertEquals($user->id, $activity->updated_by_id);
+        $this->assertTrue($user->is($activity->updated_by));
+    }
+}


### PR DESCRIPTION
Activities can be created and updated by any user of owning groups or activity admins.

This is fine, but sometimes having an owner is better.

This adds support for that, so we can contact event owners in the future.
